### PR TITLE
Support Celery v5

### DIFF
--- a/emailCULibq/tasks/tasks.py
+++ b/emailCULibq/tasks/tasks.py
@@ -1,4 +1,5 @@
-from celery.task import task
+from celery import Celery
+import celeryconfig
 import smtplib, ssl
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
@@ -8,7 +9,10 @@ username= os.getenv('EMAIL_HOST_USER')
 password= os.getenv('EMAIL_HOST_PASSWORD')
 smtp_host= os.getenv('EMAIL_SMTP_HOST')
 
-@task()
+app = Celery()
+app.config_from_object(celeryconfig)
+
+@app.task()
 def sendEmail(receiver_email,sender_email,subject,template="default_template.html.j2",template_data={"name":"CU Libraries"},verified_email='libnotify@colorado.edu'):
     """
     CU Libraries email task.


### PR DESCRIPTION
# PR Title
Support Celery v5 API changes

## Summary
This PR updates the **Email Celery Task** to work with the new Celery v5 API.

## Change Log
1. Update to follow changes in v5 of Celery API specifically removal of the celery.task module and importing directly from the Celery module instead.  This follows the changes made to the [sample cybercom task](https://github.com/cybercommons/cybercomq/tree/celery5).
2. 
## Breaking Changes
- This version of the Email task requires at least version v5.0 of Celery and has been tested with Celery v5.2.7.
